### PR TITLE
fix logging when logfile does not yet exist

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -21,7 +21,7 @@ func InitLogger(logFile, minSeverity string) {
 		targetWriter = os.Stdout
 	} else {
 		logFormatter = factorlog.NewStdFormatter(logFormat)
-		if _, err := os.Stat(logFile); err == nil {
+		if _, err = os.Stat(logFile); err != nil {
 			targetWriter, err = os.Create(logFile)
 		} else {
 			targetWriter, err = os.Open(logFile)


### PR DESCRIPTION
The := err shadows the previous err, so the panic in line 31 doesn't work. Also testing for err == nil is the other way round, the logfile needs to be created if there is an error with Stat(). Otherwise the logging does only work if there is a logfile already.