### PR TITLE
Pass connection args when checking for database

### DIFF
--- a/target/influx/Connector.go
+++ b/target/influx/Connector.go
@@ -167,7 +167,7 @@ func (connector *Connector) TestIfIsAlive() bool {
 
 //TestDatabaseExists test active if the database exists.
 func (connector *Connector) TestDatabaseExists() bool {
-	resp, err := connector.httpClient.Get(connector.connectionHost + "/query?q=show%20databases")
+	resp, err := connector.httpClient.Get(connector.connectionHost + "/query?q=show%20databases&" + connector.connectionArgs)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
You need to pass connector.connectionArgs when running 'show databases'; this command requires admin privileges, sadly.  Alternatively, we could skip the check altogether and just fail on the first attempted write if the DB doesn't exist.