### PR TITLE
fix logging to existing logfiles

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -21,11 +21,7 @@ func InitLogger(logFile, minSeverity string) {
 		targetWriter = os.Stdout
 	} else {
 		logFormatter = factorlog.NewStdFormatter(logFormat)
-		if _, err = os.Stat(logFile); err != nil {
-			targetWriter, err = os.Create(logFile)
-		} else {
-			targetWriter, err = os.Open(logFile)
-		}
+		targetWriter, err = os.OpenFile(conf.LogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	}
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
os.Open opens a file readonly, so existing logfiles never would be changed. Instead we can use OpenFile to append or create to the logfile.