### PR TITLE
Add InfluxDBGlobal.ClientTimeout option for slow InfluxDB instances

### DIFF
--- a/config.gcfg.example
+++ b/config.gcfg.example
@@ -53,6 +53,7 @@
     NastyString = ""
     NastyStringToReplace = ""
     HostcheckAlias = "hostcheck"
+    ClientTimeout  = 5
 
 [InfluxDB "nagflux"]
     Enabled = true

--- a/config/Config.go
+++ b/config/Config.go
@@ -34,6 +34,7 @@ type Config struct {
 		NastyString               string
 		NastyStringToReplace      string
 		HostcheckAlias            string
+		ClientTimeout		      int
 	}
 	InfluxDB map[string]*struct {
 		Enabled               bool

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ For further informations / bugs reportes: https://github.com/Griesbacher/nagflux
 			resultQueues[target],
 			influxConfig.Address, influxConfig.Arguments, cfg.Main.DumpFile, influxConfig.Version,
 			cfg.Main.InfluxWorker, cfg.Main.MaxInfluxWorker, cfg.InfluxDBGlobal.CreateDatabaseIfNotExists,
-			influxConfig.StopPullingDataIfDown, target,
+			influxConfig.StopPullingDataIfDown, target, cfg.InfluxDBGlobal.ClientTimeout,
 		)
 		stoppables = append(stoppables, influx)
 		influxDumpFileCollector := nagflux.NewDumpfileCollector(resultQueues[target], cfg.Main.DumpFile, target, cfg.Main.FileBufferSize)

--- a/target/influx/Connector.go
+++ b/target/influx/Connector.go
@@ -36,13 +36,13 @@ type Connector struct {
 
 //ConnectorFactory Constructor which will create some workers if the connection is established.
 func ConnectorFactory(jobs chan collector.Printable, connectionHost, connectionArgs, dumpFile, version string,
-	workerAmount, maxWorkers int, createDatabaseIfNotExists, stopReadingDataIfDown bool, target data.Target) *Connector {
+	workerAmount, maxWorkers int, createDatabaseIfNotExists, stopReadingDataIfDown bool, target data.Target, clientTimeout int) *Connector {
 	parsedArgs := helper.StringToMap(connectionArgs, "&", "=")
 	var databaseName string
 	if db, found_db := parsedArgs["db"]; found_db {
 		databaseName = db
 	}
-	timeout := time.Duration(5 * time.Second)
+	timeout := time.Duration(time.Duration(clientTimeout) * time.Second)
 	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := http.Client{Timeout: timeout, Transport: transport}
 	s := &Connector{

--- a/target/influx/Worker.go
+++ b/target/influx/Worker.go
@@ -50,7 +50,8 @@ var mutex = &sync.Mutex{}
 func WorkerGenerator(jobs chan collector.Printable, connection, dumpFile, version string,
 	connector *Connector, target data.Target, stopReadingDataIfDown bool) func(workerId int) *Worker {
 	return func(workerId int) *Worker {
-		timeout := time.Duration(5 * time.Second)
+		//timeout := time.Duration(5 * time.Second)
+		timeout := connector.httpClient.Timeout
 		transport := &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,


### PR DESCRIPTION
Hi,

we are experiencing timeouts during the HTTP api calls to heavy loaded InfluxDB instances.
Increasing the timeout and decreasing the number of workers have proven to be effective and more stable.

In this PR i added possibility to specify the timeout in seconds of the http client used for pushing data to influxdb:

```
[InfluxDBGlobal]
    [...]
    ClientTimeout  = 5
```