### PR TITLE
add StorePerformanceLabelAsField and StoreCommandAsField options

### DIFF
--- a/config.gcfg.example
+++ b/config.gcfg.example
@@ -54,6 +54,13 @@
     NastyStringToReplace = ""
     HostcheckAlias = "hostcheck"
     ClientTimeout  = 5
+    # on big installations with lot of checks that have device dependend performance labels
+    # e.g. check_interface_table, the series cardinality in influxdb can explode and therefore
+    # cause write timeouts.
+    # In such cases, setting PerformanceLabel as Field value will significantly reduce the series
+    # cardinality.
+    StoreCommandAsField = false
+    StorePerformanceLabelAsField = false
 
 [InfluxDB "nagflux"]
     Enabled = true

--- a/config/Config.go
+++ b/config/Config.go
@@ -35,6 +35,8 @@ type Config struct {
 		NastyStringToReplace      string
 		HostcheckAlias            string
 		ClientTimeout		      int
+		StoreCommandAsField	      bool
+		StorePerformanceLabelAsField bool
 	}
 	InfluxDB map[string]*struct {
 		Enabled               bool

--- a/helper/influx.go
+++ b/helper/influx.go
@@ -28,6 +28,23 @@ func SanitizeInfluxInput(input string) string {
 	return input
 }
 
+//SanitizeInfluxField escapes '"' chars only
+func SanitizeInfluxField(input string) string {
+
+	if config.GetConfig().InfluxDBGlobal.NastyString != "" {
+		input = strings.Replace(
+			input,
+			config.GetConfig().InfluxDBGlobal.NastyString,
+			config.GetConfig().InfluxDBGlobal.NastyStringToReplace,
+			-1,
+		)
+	}
+
+	input = strings.Replace(input, "\"", `\"`, -1)
+
+	return input
+}
+
 //SanitizeMap calls SanitizeInfluxInput in key and value
 func SanitizeMap(input map[string]string) map[string]string {
 	result := map[string]string{}


### PR DESCRIPTION
Hi,

On big monitoring environments with tons of checks with variable _performanceLabel_ (like disk label on disk checks or interface labels on network interface checks, etc.) the cardinality of the _performanceLabel_ tag explodes.
This causes each write to become slower and slower and memory allocation increases.

Storing the _performanceLabel_ as **Field** instead of a **Tag** in InfluxDB has proven to decrease load a lot in such situations.

This pull requests adds two options for storing the performanceLabel and the command as a Field:

```
[InfluxDBGlobal]
    [...]
    # on big installations with lot of checks that have device dependend performance labels
    # e.g. check_interface_table, the series cardinality in influxdb can explode and therefore
    # cause write timeouts.
    # In such cases, setting PerformanceLabel as Field value will significantly reduce the series
    # cardinality.
    StoreCommandAsField = false
    StorePerformanceLabelAsField = false
```